### PR TITLE
fix extended pin error

### DIFF
--- a/src/components/Pin/index.js
+++ b/src/components/Pin/index.js
@@ -4,11 +4,11 @@ const { splitLocation, filterExtData } = require('../Helpers/ForecastHelpers');
 
 export default class Pin extends Component {
 
-  getExtended(location) {
-    fetch(`http://api.wunderground.com/api/0b7e4bc2937ad616/forecast10day/q/${splitLocation(location)}.json`)
+  componentDidMount() {
+    fetch(`http://api.wunderground.com/api/0b7e4bc2937ad616/forecast10day/q/${splitLocation(this.props.data.fullName)}.json`)
     .then((response) => response.json())
     .then((data) => filterExtData(data))
-    .then((cleanData) => this.props.receiveExtForecast(cleanData, location));
+    .then((cleanData) => this.props.receiveExtForecast(cleanData, this.props.data.fullName));
   }
 
   render() {
@@ -19,9 +19,7 @@ export default class Pin extends Component {
           <p className='card-city'>{data.fullName}</p>
           <p className='card-temp'>{data.temp_f}</p>
           <p className='card-sky'>{data.weather}</p>
-          <button
-            onClick={ () => this.getExtended(data.fullName) }
-          ><Link to={'/' + data.city}>View extended forecast>>></Link></button>
+          <Link to={'/' + data.city}>View extended forecast>>></Link>
         </div>
       </div>
     )

--- a/src/components/PinExtended/index.js
+++ b/src/components/PinExtended/index.js
@@ -6,7 +6,7 @@ const PinExtended = (props) => {
     return data.city === props.params.city;
   })
   return (
-    <div>{data.fullName}</div>
+    <div>{data.extForecast[0].text}</div>
     )
 }
 


### PR DESCRIPTION
@apsitos @bekahlundy Sorry for the miss here. It was working at the coffee shop when I sent but not at home.  I think it had to do with the API calls coming back at different times.  I fixed it by putting the API call for the extended data (since it's a different call) into a componentDidMount method on the actual Pin components - basically, it will run when we add a pin to the page.

This is fixed!  Check it out and let me know if it's still giving you an issue.

FYI, if you are reloading the page ON an "Extended" link, it will NOT work because, in the re-loaded page, we no longer have the data.  Let me know if that doesn't make sense and I'll try to explain more.